### PR TITLE
Upgrade sshpk to version 1.13.2

### DIFF
--- a/onkyoalexa-master/onkyo/package.json
+++ b/onkyoalexa-master/onkyo/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://cgopal@bitbucket.org/alexa102/#readme",
   "dependencies": {
     "sshpk": "1.13.2",
+    "sshpk": "1.13.2",
     "node-forge": "1.3.0",
     "alexa-verifier": "^0.3.6",
     "body-parser": "^1.17.2",


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades sshpk to 1.13.2 to fix vulnerabilities in current version